### PR TITLE
Keep old reports unchanged after item edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is a simple Node.js/Express web application with an SQLite database for man
 
 The main page allows you to add items and shows the last five entries. A second page at `/report` lets you build damage reports. At the top of each report you can enter the supervisor name, police report number, street, state, and a short location description. Choose a category, enter quantities for items and press **Add Items** to build up your report. When finished, click **Save Report** to store it or **Discard Report** to clear the form. Each saved report shows the total cost of its items. Use the **Download PDF** button to export a nicely formatted report with your header information and an itemized table.
 
+Saved reports keep a snapshot of every item's description, unit and cost. Editing or deleting items later will not alter the information shown in previous reports.
+
 The repository includes placeholder files at `public/amiri.ttf` and `public/logo.png`. Before exporting PDFs, download the real Amiri font from the [official releases](https://github.com/aliftype/amiri/releases) and place your 333 × 333 PNG logo in these paths, replacing the placeholders.
 
 ## Development


### PR DESCRIPTION
## Summary
- store description, unit and cost in `report_items` when creating a report
- adjust all report queries to use the snapshot columns
- migrate existing databases to include the new columns
- update README with note about snapshots

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856629e9bb48325947469c81a28e787