### PR TITLE
Add signature placeholder and update PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An extra admin interface is available at `/admin` where you can upload a plain t
 
 Saved reports keep a snapshot of every item's description, unit and cost. Editing or deleting items later will not alter the information shown in previous reports.
 
-The repository includes placeholder files at `public/amiri.ttf` and `public/logo.png`. Before exporting PDFs, download the real Amiri font from the [official releases](https://github.com/aliftype/amiri/releases) and place your 333 × 333 PNG logo in these paths, replacing the placeholders.
+The repository includes placeholder files at `public/amiri.ttf`, `public/logo.png` and `public/sig.png`. Before exporting PDFs, download the real Amiri font from the [official releases](https://github.com/aliftype/amiri/releases), place your 333 × 333 PNG logo at `public/logo.png`, and replace `public/sig.png` with your signature image. The signature will appear in the bottom‑right corner of generated reports.
 
 ## Development
 

--- a/public/doc.js
+++ b/public/doc.js
@@ -104,6 +104,24 @@ async function downloadPdf(id) {
     });
     y += 8;
     doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+
+    // Add signature image at the bottom right if available
+    try {
+        const sigRes = await fetch('/sig.png');
+        if (sigRes.ok) {
+            const sigBuf = await sigRes.arrayBuffer();
+            const sigBase64 = bufferToBase64(sigBuf);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            const pageHeight = doc.internal.pageSize.getHeight();
+            const sigW = 30;
+            const sigH = 15;
+            doc.addImage('data:image/png;base64,' + sigBase64, 'PNG',
+                pageWidth - sigW - 10, pageHeight - sigH - 10, sigW, sigH);
+        }
+    } catch (e) {
+        console.warn('signature missing or failed to load');
+    }
+
     doc.save(`report-${id}.pdf`);
 }
 

--- a/public/report.js
+++ b/public/report.js
@@ -267,6 +267,24 @@ async function downloadPdf(id) {
     });
     y += 8;
     doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+
+    // Add signature image at the bottom right if available
+    try {
+        const sigRes = await fetch('/sig.png');
+        if (sigRes.ok) {
+            const sigBuf = await sigRes.arrayBuffer();
+            const sigBase64 = bufferToBase64(sigBuf);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            const pageHeight = doc.internal.pageSize.getHeight();
+            const sigW = 30;
+            const sigH = 15;
+            doc.addImage('data:image/png;base64,' + sigBase64, 'PNG',
+                pageWidth - sigW - 10, pageHeight - sigH - 10, sigW, sigH);
+        }
+    } catch (e) {
+        console.warn('signature missing or failed to load');
+    }
+
     doc.save(`report-${id}.pdf`);
 }
 

--- a/public/sig.png
+++ b/public/sig.png
@@ -1,0 +1,1 @@
+placeholder signature


### PR DESCRIPTION
## Summary
- draw optional signature image in generated PDFs
- document `public/sig.png` placeholder in README
- add `public/sig.png` placeholder file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68584a6b0c3c83259ce012f44fdee421