### PR TITLE
Fix item sorting

### DIFF
--- a/server.js
+++ b/server.js
@@ -194,7 +194,8 @@ app.get('/api/items/all', (req, res) => {
     query += ' WHERE category = ?';
     params.push(category);
   }
-  query += ' ORDER BY description';
+  // Preserve insertion order instead of alphabetical
+  query += ' ORDER BY id';
   db.all(query, params, (err, rows) => {
     if (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- preserve bulk-uploaded item order by sorting database query by id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68594b7e8e488325a132a6744e636139