### PR TITLE
Show all categories on report page

### DIFF
--- a/public/report.js
+++ b/public/report.js
@@ -33,15 +33,24 @@ async function loadCategories() {
     const categories = await res.json();
     const select = document.getElementById('categorySelect');
     select.innerHTML = '';
-    categories.forEach((cat, idx) => {
+
+    // Add option to show all items regardless of category
+    const allOpt = document.createElement('option');
+    allOpt.value = '';
+    allOpt.textContent = 'كل الأصناف';
+    select.appendChild(allOpt);
+
+    categories.forEach((cat) => {
         const opt = document.createElement('option');
         opt.value = cat;
         opt.textContent = cat;
         select.appendChild(opt);
-        if (idx === 0) select.value = cat;
     });
+
+    // Default to showing all items
+    select.value = '';
     if (categories.length > 0) {
-        loadItems(select.value);
+        loadItems();
     } else {
         document.getElementById('itemsList').innerHTML = '<p>لا يوجد</p>';
     }


### PR DESCRIPTION
## Summary
- update `loadCategories` to include an `all` option and load every item by default

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685acca7d7948325957cc28bb8612706