### PR TITLE
Show all categories on report page

### DIFF
--- a/public/report.js
+++ b/public/report.js
@@ -33,15 +33,24 @@ async function loadCategories() {
     const categories = await res.json();
     const select = document.getElementById('categorySelect');
     select.innerHTML = '';
-    categories.forEach((cat, idx) => {
+
+    // Add option to show all items regardless of category
+    const allOpt = document.createElement('option');
+    allOpt.value = '';
+    allOpt.textContent = 'كل الأصناف';
+    select.appendChild(allOpt);
+
+    categories.forEach((cat) => {
         const opt = document.createElement('option');
         opt.value = cat;
         opt.textContent = cat;
         select.appendChild(opt);
-        if (idx === 0) select.value = cat;
     });
+
+    // Default to showing all items
+    select.value = '';
     if (categories.length > 0) {
-        loadItems(select.value);
+        loadItems();
     } else {
         document.getElementById('itemsList').innerHTML = '<p>لا يوجد</p>';
     }

--- a/public/script.js
+++ b/public/script.js
@@ -1,7 +1,8 @@
 let editingId = null;
 
 async function fetchItems() {
-    const res = await fetch('/api/items');
+    // Load all items instead of just the most recent five
+    const res = await fetch('/api/items/all');
     const items = await res.json();
     const tbody = document.querySelector('#itemsTable tbody');
     tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- update `fetchItems` in the main page script to load every item rather than only the latest five

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685acca7d7948325957cc28bb8612706