### PR TITLE
Enable coordinate editing when modifying reports

### DIFF
--- a/public/report.js
+++ b/public/report.js
@@ -336,6 +336,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (editingId) {
         await loadExistingReport(editingId);
         document.querySelector('#reportForm button[type="submit"]').textContent = 'حفظ التعديلات';
+        // Allow manual editing of coordinates when updating a report
+        const coordsInput = document.getElementById('coordinates');
+        if (coordsInput) {
+            coordsInput.removeAttribute('readonly');
+        }
     } else {
         loadReport();
     }


### PR DESCRIPTION
## Summary
- allow manually editing coordinates when editing an existing report

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865335b6ba08325b055b146d540d945