### PR TITLE
Add report date to PDF exports

### DIFF
--- a/public/doc.js
+++ b/public/doc.js
@@ -59,6 +59,7 @@ async function downloadPdf(id) {
     doc.setFontSize(12);
     const headerRows = [
         ['رقم التقرير', String(id)],
+        ['التاريخ', new Date(data.created_at).toLocaleDateString()],
         ['المشرف / المهندس', data.supervisor || ''],
         ['رقم مرجع الشرطة', data.police_report || ''],
         ['اسم الطريق', data.street || ''],

--- a/public/report.js
+++ b/public/report.js
@@ -239,6 +239,7 @@ async function downloadPdf(id) {
     doc.setFontSize(12);
     const headerRows = [
         ['رقم التقرير', String(id)],
+        ['التاريخ', new Date(data.created_at).toLocaleDateString()],
         ['المشرف / المهندس', data.supervisor || ''],
         ['رقم مرجع الشرطة', data.police_report || ''],
         ['اسم الطريق', data.street || ''],


### PR DESCRIPTION
## Summary
- include the report creation date in PDF headers for report downloads

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866d98b99388325b9f0bc551b46ee53