### PR TITLE
Add notes field to report form

### DIFF
--- a/public/report.html
+++ b/public/report.html
@@ -37,6 +37,11 @@
                 <small id="accuracyCounter" class="ms-2 text-muted"></small>
             </div>
         </div>
+        <div class="row g-3 mb-3">
+            <div class="col-12">
+                <textarea id="notes" class="form-control" rows="3" placeholder="ملاحظات"></textarea>
+            </div>
+        </div>
         <select id="categorySelect" class="form-select mb-3"></select>
         <div id="itemsList" class="mb-3"></div>
         <button id="addItemsBtn" class="btn btn-secondary mb-3" type="button">إضافة</button>


### PR DESCRIPTION
## Summary
- add a textarea for notes in the damage report form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686774804b6083259d9c8ae963352122