### PR TITLE
Make geolocation accuracy configurable

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -15,6 +15,15 @@
         <button class="btn btn-primary" type="submit">رفع</button>
     </form>
     <div id="uploadResult" class="mt-3"></div>
+
+    <hr class="my-4">
+    <h2 class="mb-3">إعدادات الموقع</h2>
+    <div class="mb-3">
+        <label for="accuracyInput" class="form-label">الدقة المطلوبة بالمتر</label>
+        <input type="number" id="accuracyInput" min="1" step="1" class="form-control">
+    </div>
+    <button id="saveAccuracyBtn" class="btn btn-secondary mb-3" type="button">حفظ الإعداد</button>
+    <div id="accuracyResult" class="mt-2"></div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/admin.js"></script>

--- a/public/admin.js
+++ b/public/admin.js
@@ -22,3 +22,42 @@ document.getElementById('uploadForm').addEventListener('submit', async (e) => {
         result.textContent = 'فشل رفع الملف';
     }
 });
+
+async function loadAccuracy() {
+    try {
+        const res = await fetch('/api/settings/accuracyThreshold');
+        if (res.ok) {
+            const data = await res.json();
+            if (data.value !== null) {
+                document.getElementById('accuracyInput').value = parseFloat(data.value);
+            }
+        }
+    } catch (e) {
+        console.warn('failed to load accuracy setting');
+    }
+}
+
+async function saveAccuracy() {
+    const val = parseFloat(document.getElementById('accuracyInput').value);
+    const result = document.getElementById('accuracyResult');
+    if (isNaN(val) || val <= 0) {
+        result.textContent = 'قيمة غير صالحة';
+        return;
+    }
+    const res = await fetch('/api/settings/accuracyThreshold', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: val })
+    });
+    if (res.ok) {
+        result.textContent = 'تم الحفظ';
+    } else {
+        result.textContent = 'فشل الحفظ';
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    loadAccuracy();
+    const btn = document.getElementById('saveAccuracyBtn');
+    if (btn) btn.addEventListener('click', saveAccuracy);
+});

--- a/public/report.js
+++ b/public/report.js
@@ -1,5 +1,20 @@
 let editingId = null;
 
+let accuracyThreshold = 5;
+
+async function loadAccuracySetting() {
+    try {
+        const res = await fetch('/api/settings/accuracyThreshold');
+        if (res.ok) {
+            const data = await res.json();
+            const val = parseFloat(data.value);
+            if (!isNaN(val)) accuracyThreshold = val;
+        }
+    } catch (e) {
+        console.warn('failed to load accuracy setting');
+    }
+}
+
 function bufferToBase64(buf) {
     let binary = "";
     const bytes = new Uint8Array(buf);
@@ -196,7 +211,7 @@ function getCoords() {
         (pos) => {
             const acc = pos.coords.accuracy;
             accuracyEl.textContent = `الدقة ${acc.toFixed(1)}م`;
-            if (acc <= 5) {
+            if (acc <= accuracyThreshold) {
                 const lat = pos.coords.latitude;
                 const lon = pos.coords.longitude;
                 const code = olc.encode(lat, lon);
@@ -333,6 +348,7 @@ async function downloadPdf(id) {
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
+    await loadAccuracySetting();
     editingId = new URLSearchParams(window.location.search).get('id');
     await loadCategories();
     document.getElementById('categorySelect').addEventListener('change', (e) => {


### PR DESCRIPTION
## Summary
- add a `settings` table with default accuracy value
- expose API endpoints to get/set settings
- allow admins to adjust the required location accuracy
- load the setting in the report page and use it when collecting coordinates

## Testing
- `node -c server.js`
- `node -c public/report.js`
- `node -c public/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6867c2fd1dc083259c8784fb6cc04da0