### PR TITLE
Allow empty reports

### DIFF
--- a/public/doc.js
+++ b/public/doc.js
@@ -104,16 +104,21 @@ async function downloadPdf(id) {
         y += 8;
     }
 
-    drawItemRow('الوصف', 'التكلفة', 'الكمية', 'المجموع');
-    data.items.forEach(it => {
-        drawItemRow(it.description, it.cost.toFixed(2), String(it.quantity), it.line_total.toFixed(2));
-        if (y > 270) {
-            doc.addPage();
-            y = 20;
-        }
-    });
-    y += 8;
-    doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+    if (data.items.length === 0) {
+        doc.text('لا يوجد أضرار', 105, y + 4, { align: 'center' });
+        y += 8;
+    } else {
+        drawItemRow('الوصف', 'التكلفة', 'الكمية', 'المجموع');
+        data.items.forEach(it => {
+            drawItemRow(it.description, it.cost.toFixed(2), String(it.quantity), it.line_total.toFixed(2));
+            if (y > 270) {
+                doc.addPage();
+                y = 20;
+            }
+        });
+        y += 8;
+        doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+    }
 
     // Add supervisor title, signing line and signature centered at the bottom
     try {

--- a/public/report.js
+++ b/public/report.js
@@ -143,10 +143,6 @@ async function loadExistingReport(id) {
 
 async function handleSubmit(e) {
     e.preventDefault();
-    if (currentItems.length === 0) {
-        alert('الرجاء إضافة الأصناف قبل حفظ التقرير');
-        return;
-    }
     const payload = currentItems.map(it => ({ itemId: it.itemId, quantity: it.quantity }));
     const supervisor = document.getElementById('supervisor').value;
     const police_report = document.getElementById('policeNumber').value;
@@ -302,16 +298,21 @@ async function downloadPdf(id) {
         y += 8;
     }
 
-    drawItemRow('الوصف', 'التكلفة', 'الكمية', 'المجموع');
-    data.items.forEach(it => {
-        drawItemRow(it.description, it.cost.toFixed(2), String(it.quantity), it.line_total.toFixed(2));
-        if (y > 270) {
-            doc.addPage();
-            y = 20;
-        }
-    });
-    y += 8;
-    doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+    if (data.items.length === 0) {
+        doc.text('لا يوجد أضرار', 105, y + 4, { align: 'center' });
+        y += 8;
+    } else {
+        drawItemRow('الوصف', 'التكلفة', 'الكمية', 'المجموع');
+        data.items.forEach(it => {
+            drawItemRow(it.description, it.cost.toFixed(2), String(it.quantity), it.line_total.toFixed(2));
+            if (y > 270) {
+                doc.addPage();
+                y = 20;
+            }
+        });
+        y += 8;
+        doc.text(`المجموع الكلي: OMR${data.total.toFixed(2)}`, 200 - 10, y, { align: 'right' });
+    }
 
     // Add approval text and signature at the bottom center if available
     try {


### PR DESCRIPTION
## Summary
- remove client-side check that prevented saving empty damage reports
- show **لا يوجد أضرار** in generated PDFs when a report has no items
- permit POST/PUT of reports without items and adjust queries to include those reports

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867cf29b44883258923766e094ea3f1